### PR TITLE
DnD Refactor - Drag Multiple Points At Once

### DIFF
--- a/src/actions/constants.ts
+++ b/src/actions/constants.ts
@@ -30,12 +30,16 @@ export const Actions = {
   setMessage: "setMessage",
   pointCreate: "pointCreate",
   pointUpdate: "pointUpdate",
-  pointMove: "pointMove",
+  pointsMove: "pointsMove",
   pointsDelete: "pointsDelete",
   setFocus: "setFocus",
   setMainPoint: "setMainPoint",
   combinePoints: "combinePoints",
   splitIntoTwoPoints: "splitIntoTwoPoints",
+
+  beginDrag: "beginDrag",
+  hoverOver: "hoverOver",
+  endDrag: "endDrag",
 
   setExpandedRegion: "setExpandedRegion",
 

--- a/src/actions/dragActions.ts
+++ b/src/actions/dragActions.ts
@@ -1,0 +1,22 @@
+import { Action, Actions } from "./constants";
+
+export interface HoverOverParams {
+  index: number;
+  region: string;
+}
+
+export const hoverOver = (params: HoverOverParams): Action<HoverOverParams> => {
+  return {
+    type: Actions.hoverOver,
+    params,
+  };
+};
+
+export interface EndDragParams {}
+
+export const endDrag = (params: EndDragParams): Action<EndDragParams> => {
+  return {
+    type: Actions.endDrag,
+    params,
+  };
+};

--- a/src/actions/messageActions.ts
+++ b/src/actions/messageActions.ts
@@ -34,11 +34,7 @@ import { PointI, PointShape } from "../dataModels/dataModels";
 //  };
 //};
 
-export interface SetFocusParams {
-  pointId: string;
-  oldIndex: number;
-  originalShape: PointShape;
-}
+export interface SetFocusParams {}
 
 export const setFocus = (params: SetFocusParams): Action<SetFocusParams> => {
   return {

--- a/src/actions/pointsActions.ts
+++ b/src/actions/pointsActions.ts
@@ -56,16 +56,16 @@ export const pointUpdate = (
   };
 };
 
-export interface PointMoveParams {
-  pointId: string;
-  oldIndex?: number;
-  newShape: PointShape;
-  newIndex: number;
-}
+//TODO: Should we leave this as an empty interface? or remove it
+//entirely so that we don't have to pass an empty object when calling
+//pointsMove?
+export interface PointsMoveParams {}
 
-export const pointMove = (params: PointMoveParams): Action<PointMoveParams> => {
+export const pointsMove = (
+  params: PointsMoveParams
+): Action<PointsMoveParams> => {
   return {
-    type: Actions.pointMove,
+    type: Actions.pointsMove,
     params,
   };
 };

--- a/src/components/FocusPoint.tsx
+++ b/src/components/FocusPoint.tsx
@@ -68,14 +68,13 @@ const FocusPoint = (props: AllProps) => {
 
   const imageUrl = require(`../images/${shape}.svg`);
 
-  const { isDragging, drag, preview } = useDragPoint(pointId);
+  const { drag, preview } = useDragPoint(pointId, 0);
 
   return (
     <StyledSpan
       onClick={props.onClick}
       ref={preview}
       isMainPoint={isMainPoint}
-      isDragging={isDragging}
       isSelected={props.isSelected}
       referenceAuthor={props.referenceAuthor}
     >

--- a/src/components/FocusRegion.tsx
+++ b/src/components/FocusRegion.tsx
@@ -39,6 +39,7 @@ import {
   togglePoint,
   TogglePointParams,
 } from "../actions/selectPointActions";
+import { hoverOver, HoverOverParams } from "../actions/dragActions";
 
 interface OwnProps {
   region: RegionI;
@@ -57,6 +58,7 @@ interface AllProps extends OwnProps {
   pointCreate: (params: PointCreateParams) => void;
   togglePoint: (params: TogglePointParams) => void;
   setSelectedPoints: (params: SetSelectedPointsParams) => void;
+  hoverOver: (params: HoverOverParams) => void;
 }
 
 //TODO: don't pass region to FocusRegion, since its only ever the
@@ -66,19 +68,22 @@ const FocusRegion = (props: AllProps) => {
 
   const [, drop] = useDrop({
     accept: ItemTypes.POINT,
-    hover: () => {
+    hover: (item: DraggablePointType) => {
       if (isExpanded !== "expanded") {
         props.setExpandedRegion({ region });
       }
-    },
-    drop: (item: DraggablePointType) => {
-      if (typeof item.index === "number") {
-        props.setFocus({
-          pointId: item.pointId,
-          oldIndex: item.index,
-          originalShape: item.originalShape,
+      if (item.index !== 0 || item.region !== "focus") {
+        props.hoverOver({
+          index: 0,
+          region: "focus",
         });
+
+        item.index = 0;
+        item.region = "focus";
       }
+    },
+    drop: () => {
+      props.setFocus({});
     },
   });
 
@@ -158,6 +163,7 @@ const mapDispatchToProps = {
   pointCreate,
   togglePoint,
   setSelectedPoints,
+  hoverOver,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FocusRegion);

--- a/src/components/MeritsRegion.tsx
+++ b/src/components/MeritsRegion.tsx
@@ -45,15 +45,6 @@ const MeritsRegion = (props: {
         props.setExpandedRegion({ region });
       }
     },
-    //    drop: (item: DraggablePointType) => {
-    //      appDispatch({
-    //        type: "setFocus",
-    //        pointId: item.pointId,
-    //        oldShape: item.shape,
-    //        oldIndex: item.index,
-    //        newShape: item.originalShape,
-    //      });
-    //    },
   });
 
   return (

--- a/src/components/RegionHeader.tsx
+++ b/src/components/RegionHeader.tsx
@@ -20,16 +20,19 @@ import React from "react";
 import { PointShape } from "../dataModels/dataModels";
 import styled from "styled-components";
 
-const RegionHeader = (props: { shape: PointShape; darkMode?: boolean }) => {
-  const imageUrl = require(`../images/${props.shape}.svg`);
+//TODO: Properly type ref
+const RegionHeader = React.forwardRef(
+  (props: { shape: PointShape; darkMode?: boolean }, ref: any) => {
+    const imageUrl = require(`../images/${props.shape}.svg`);
 
-  return (
-    <StyledSpan darkMode={props.darkMode}>
-      <img src={imageUrl} height={17} alt={props.shape} />
-      {props.shape.slice(0, 1).toUpperCase() + props.shape.slice(1)}
-    </StyledSpan>
-  );
-};
+    return (
+      <StyledSpan ref={ref} darkMode={props.darkMode}>
+        <img src={imageUrl} height={17} alt={props.shape} />
+        {props.shape.slice(0, 1).toUpperCase() + props.shape.slice(1)}
+      </StyledSpan>
+    );
+  }
+);
 
 interface StyledProps {
   darkMode?: boolean;

--- a/src/components/StyledPoint.tsx
+++ b/src/components/StyledPoint.tsx
@@ -22,7 +22,6 @@ import { AuthorI } from "../dataModels/dataModels";
 
 interface StyledPointProps {
   isMainPoint?: boolean;
-  isDragging?: boolean;
   isSelected?: boolean;
   referenceAuthor?: AuthorI;
   darkMode?: boolean;
@@ -30,7 +29,6 @@ interface StyledPointProps {
 
 export const StyledSpan = styled.span<StyledPointProps>`
   position: relative;
-  opacity: ${(props) => (props.isDragging ? 0.4 : 1)};
   ${(props) =>
     props.referenceAuthor &&
     `padding: 0.3rem 0.8rem 0.2rem 0.2rem;

--- a/src/constants/React-Dnd.tsx
+++ b/src/constants/React-Dnd.tsx
@@ -16,17 +16,17 @@
   You should have received a copy of the GNU Affero General Public License
   along with U4U.  If not, see <https://www.gnu.org/licenses/>.
 */
-import { PointI, PointShape } from "../dataModels/dataModels";
+import { RegionI } from "../dataModels/dataModels";
 
+//TODO: How do we remove EndDragParams in src/actions/dragActions.ts?
+
+//TODO: rename to POINTS?
 export const ItemTypes = {
   POINT: "point",
 };
 
 export interface DraggablePointType {
   type: "point";
-  pointId: PointI["_id"];
-  shape: PointShape;
-  index?: number;
-  originalShape: PointShape;
-  isReferencedPoint: boolean;
+  region: RegionI;
+  index: number;
 }

--- a/src/dataModels/dataModels.ts
+++ b/src/dataModels/dataModels.ts
@@ -37,6 +37,10 @@ export const allPointShapes: PointShape[] = [
   "people",
 ];
 
+export function isPointShape(region: string): region is PointShape {
+  return (allPointShapes as string[]).includes(region);
+}
+
 export type PointShapeWithEmpty = PointShape | "";
 
 export type RegionI = PointShape | "merits" | "focus";

--- a/src/reducers/drag.ts
+++ b/src/reducers/drag.ts
@@ -1,0 +1,56 @@
+import { Action, Actions } from "../actions/constants";
+import { AppState } from "./store";
+
+import { HoverOverParams, EndDragParams } from "../actions/dragActions";
+
+interface DragContext {
+  index: number;
+  region: string;
+}
+
+export interface DragState {
+  context: DragContext | null;
+}
+
+export const initialDragState: DragState = {
+  context: null,
+};
+
+export const dragReducer = (
+  state: DragState,
+  action: Action,
+  appState: AppState
+): DragState => {
+  let newState = state;
+  switch (action.type) {
+    case Actions.hoverOver:
+      newState = handleHoverOver(state, action as Action<HoverOverParams>);
+      break;
+    case Actions.endDrag:
+      newState = handleEndDrag(state, action as Action<EndDragParams>);
+      break;
+  }
+
+  return newState;
+};
+
+function handleHoverOver(
+  state: DragState,
+  action: Action<HoverOverParams>
+): DragState {
+  return {
+    context: {
+      index: action.params.index,
+      region: action.params.region,
+    },
+  };
+}
+
+function handleEndDrag(
+  state: DragState,
+  action: Action<EndDragParams>
+): DragState {
+  return {
+    context: null,
+  };
+}

--- a/src/reducers/store.ts
+++ b/src/reducers/store.ts
@@ -39,6 +39,7 @@ import {
   SelectedPointsState,
 } from "./selectedPoints";
 import { initialPanelsState, panelsReducer, PanelsState } from "./panels";
+import { initialDragState, dragReducer, DragState } from "./drag";
 
 import { authors, messages, points } from "../constants/initialState";
 
@@ -56,6 +57,7 @@ export interface AppState {
   expandedRegion: ExpandedRegionState;
   selectedPoints: SelectedPointsState;
   panels: PanelsState;
+  drag: DragState;
 }
 
 function createAppStore() {
@@ -67,6 +69,7 @@ function createAppStore() {
     expandedRegion: initialExpandedRegionState,
     selectedPoints: initialSelectedPointsState,
     panels: initialPanelsState,
+    drag: initialDragState,
   };
 
   const appReducer = (state = initialAppState, action: Action): AppState => {
@@ -90,6 +93,7 @@ function createAppStore() {
         state
       ),
       panels: panelsReducer(state.panels, action, state),
+      drag: dragReducer(state.drag, action, state),
     };
     return newState;
   };


### PR DESCRIPTION
    * redux now tracks the drag context
    * refactor DnD logic to move points on drop instead of hover
    * pointMove ==> pointsMove. Move multiple points at once.
    * setFocus dispatch no longer takes any params, it determines the new focus based on the selectedPoints arraytrue
    * no longer use isDragging for styling
    * don't render NewPointButton when region is hovered